### PR TITLE
fix: resolve 3 critical bugs blocking admin and clinic dashboards

### DIFF
--- a/internal/handler/appointments/appointments_handler.go
+++ b/internal/handler/appointments/appointments_handler.go
@@ -38,23 +38,21 @@ func NewAppointmentHandler(
 
 // RegisterRoutes registers appointment routes
 func (h *AppointmentHandler) RegisterRoutes(router chi.Router) {
-	router.Route("/appointments", func(r chi.Router) {
-		r.Post("/", h.CreateAppointment)
-		r.Get("/{id}", h.GetAppointmentByID)
-		r.Get("/patient/{patientId}", h.GetAppointmentsByPatient)
-		r.Get("/clinic/{clinicId}", h.GetAppointmentsByClinic)
-		r.Get("/clinic/{clinicId}/date/{date}", h.GetAppointmentsByClinicAndDate)
-		r.Get("/clinic/{clinicId}/today", h.GetTodayAppointments)
-		r.Get("/clinic/{clinicId}/pending", h.GetPendingAppointments)
-		r.Put("/{id}/reschedule", h.RescheduleAppointment)
-		r.Put("/{id}/confirm", h.ConfirmAppointment)
-		r.Put("/{id}/notes", h.UpdateAppointmentNotes)
-		r.Put("/{id}/complete", h.CompleteAppointment)
-		r.Put("/{id}/cancel", h.CancelAppointment)
-		r.Put("/{id}/status", h.UpdateAppointmentStatus)
-		r.Delete("/{id}", h.DeleteAppointment)
-		r.Get("/patient/{patientId}/count", h.GetAppointmentCount)
-	})
+	router.Post("/", h.CreateAppointment)
+	router.Get("/{id}", h.GetAppointmentByID)
+	router.Get("/patient/{patientId}", h.GetAppointmentsByPatient)
+	router.Get("/clinic/{clinicId}", h.GetAppointmentsByClinic)
+	router.Get("/clinic/{clinicId}/date/{date}", h.GetAppointmentsByClinicAndDate)
+	router.Get("/clinic/{clinicId}/today", h.GetTodayAppointments)
+	router.Get("/clinic/{clinicId}/pending", h.GetPendingAppointments)
+	router.Put("/{id}/reschedule", h.RescheduleAppointment)
+	router.Put("/{id}/confirm", h.ConfirmAppointment)
+	router.Put("/{id}/notes", h.UpdateAppointmentNotes)
+	router.Put("/{id}/complete", h.CompleteAppointment)
+	router.Put("/{id}/cancel", h.CancelAppointment)
+	router.Put("/{id}/status", h.UpdateAppointmentStatus)
+	router.Delete("/{id}", h.DeleteAppointment)
+	router.Get("/patient/{patientId}/count", h.GetAppointmentCount)
 }
 
 // CreateAppointment handles creation of a new appointment

--- a/internal/handler/core/user_handler.go
+++ b/internal/handler/core/user_handler.go
@@ -651,12 +651,31 @@ func (h *UserHandler) GetUsersByIDs(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// CountUsers counts users by role
+// CountUsers counts users by role or all users if no role specified
 func (h *UserHandler) CountUsers(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), h.timeout)
 	defer cancel()
 
 	role := r.URL.Query().Get("role")
+
+	if role == "" {
+		// Count all users by summing across known roles
+		roles := []string{"patient", "caregiver", "provider_staff", "clinic_admin", "system_admin", "ngo_partner"}
+		var total int64
+		for _, r := range roles {
+			c, err := h.userService.CountUsers(ctx, r)
+			if err != nil {
+				h.logger.Warn().Err(err).Str("role", r).Msg("Failed to count users for role")
+				continue
+			}
+			total += c
+		}
+		handler.RespondJSON(w, http.StatusOK, map[string]interface{}{
+			"count": total,
+			"role":  "",
+		})
+		return
+	}
 
 	count, err := h.userService.CountUsers(ctx, role)
 	if err != nil {

--- a/internal/repository/core/user_repository.go
+++ b/internal/repository/core/user_repository.go
@@ -429,6 +429,9 @@ func (r *userRepository) mapToUserFromGetByID(u sqlc.GetUserByIDRow) core.User {
 		LoginCount:           int(u.LoginCount.Int32),
 		IsSMSOnly:            pgtypeBoolToBool(u.IsSmsOnly),
 		ProfileCompletionPct: int(u.ProfileCompletionPercentage.Int32),
+		PrimaryClinicID:      pgtypeUUIDToUUIDPtr(u.PrimaryClinicID),
+		OnboardingCompleted:  pgtypeBoolToBool(u.OnboardingCompleted),
+		OnboardingStep:       pgtypeTextToStringPtr(u.OnboardingStep),
 		CreatedAt:            u.CreatedAt.Time,
 		UpdatedAt:            u.UpdatedAt.Time,
 	}


### PR DESCRIPTION
## Summary
Fixes 3 bugs that prevented the clinic_admin and system_admin dashboards from functioning.

## Changes

### 1. Fix mapToUserFromGetByID missing fields (closes #40)
`internal/repository/core/user_repository.go` - Added `PrimaryClinicID`, `OnboardingCompleted`, and `OnboardingStep` field mappings that were being selected by the SQL query but never mapped to the domain struct. This was causing `GET /api/v1/providers/clinics/my-clinic` to always return 404.

### 2. Fix CountUsers returning 0 without role parameter (closes #41)
`internal/handler/core/user_handler.go` - When no `role` query parameter is provided, iterates through all known roles and sums their counts. Previously the SQL query `WHERE role = $1` would match empty string and return 0.

### 3. Fix double-nested appointment routes (closes #42)
`internal/handler/appointments/appointments_handler.go` - Removed the inner `router.Route("/appointments", ...)` wrapper since the router passed to `RegisterRoutes` is already scoped to `/appointments`. This was causing `/api/v1/appointments/appointments/clinic/{id}/today` instead of `/api/v1/appointments/clinic/{id}/today`.

## Testing
- `GET /api/v1/providers/clinics/my-clinic` now returns clinic data
- `GET /api/v1/users/count` returns total user count (6)
- `GET /api/v1/appointments/clinic/{id}/today` returns 200 instead of 404
- `GET /api/v1/appointments/clinic/{id}/pending` returns 200 instead of 404