### PR TITLE
Align Docker and CI toolchain versions with go.mod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
       - run: go test ./...
       - name: Lint changed files
         run: |
+          export GOTOOLCHAIN=go1.25.10
           go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
           BASE_REF="${GITHUB_BASE_REF:-main}"
           if [ -z "$BASE_REF" ]; then
@@ -49,6 +50,7 @@ jobs:
           fi
       - name: Security check
         run: |
+          export GOTOOLCHAIN=go1.25.10
           go install golang.org/x/vuln/cmd/govulncheck@latest
           govulncheck ./...
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,27 +8,10 @@ jobs:
   fast-checks:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout source
-        run: |
-          REPO="${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}"
-          REF="${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}"
-          git clone --depth 1 --branch "$REF" "https://github.com/$REPO.git" .
-      - name: Setup Go
-        run: |
-          GO_VERSION="$(awk '/^go / { print $2; exit }' go.mod | tr -d '\r')"
-          if [ -z "$GO_VERSION" ]; then
-            GO_VERSION="1.24.0"
-          fi
-          if [[ "$GO_VERSION" != *.*.* ]]; then
-            GO_VERSION="${GO_VERSION}.0"
-          fi
-          curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" -o "/tmp/go${GO_VERSION}.linux-amd64.tar.gz"
-          sudo rm -rf /usr/local/go
-          sudo tar -C /usr/local -xzf "/tmp/go${GO_VERSION}.linux-amd64.tar.gz"
-          echo "/usr/local/go/bin" >> "$GITHUB_PATH"
-          mkdir -p "$HOME/go/bin"
-          echo "$HOME/go/bin" >> "$GITHUB_PATH"
-          echo "GOBIN=$HOME/go/bin" >> "$GITHUB_ENV"
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
       - run: go mod download
       - run: go mod verify
       - run: go build ./...
@@ -41,13 +24,15 @@ jobs:
           if [ -z "$BASE_REF" ]; then
             BASE_REF="main"
           fi
-        if [ "$BASE_REF" = "main" ] || [ "$BASE_REF" = "develop" ]; then
-            git fetch --depth=1 origin "refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF"
+          if [ "$BASE_REF" = "main" ] || [ "$BASE_REF" = "develop" ]; then
+            git fetch --depth=1 origin "$BASE_REF"
             golangci-lint run --timeout 10m --new-from-rev="origin/$BASE_REF" ./...
           else
             golangci-lint run --timeout 10m ./...
           fi
       - name: Security check
+        env:
+          GOTOOLCHAIN: go1.24.0
         run: |
           go install golang.org/x/vuln/cmd/govulncheck@latest
           govulncheck ./...
@@ -55,27 +40,10 @@ jobs:
   integration-checks:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout source
-        run: |
-          REPO="${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}"
-          REF="${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}"
-          git clone --depth 1 --branch "$REF" "https://github.com/$REPO.git" .
-      - name: Setup Go
-        run: |
-          GO_VERSION="$(awk '/^go / { print $2; exit }' go.mod | tr -d '\r')"
-          if [ -z "$GO_VERSION" ]; then
-            GO_VERSION="1.24.0"
-          fi
-          if [[ "$GO_VERSION" != *.*.* ]]; then
-            GO_VERSION="${GO_VERSION}.0"
-          fi
-          curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" -o "/tmp/go${GO_VERSION}.linux-amd64.tar.gz"
-          sudo rm -rf /usr/local/go
-          sudo tar -C /usr/local -xzf "/tmp/go${GO_VERSION}.linux-amd64.tar.gz"
-          echo "/usr/local/go/bin" >> "$GITHUB_PATH"
-          mkdir -p "$HOME/go/bin"
-          echo "$HOME/go/bin" >> "$GITHUB_PATH"
-          echo "GOBIN=$HOME/go/bin" >> "$GITHUB_ENV"
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
       - run: go mod download
       - name: Run integration tests
         run: go test -tags=integration ./tests/integration
@@ -83,27 +51,10 @@ jobs:
   generated-code-drift:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout source
-        run: |
-          REPO="${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}"
-          REF="${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}"
-          git clone --depth 1 --branch "$REF" "https://github.com/$REPO.git" .
-      - name: Setup Go
-        run: |
-          GO_VERSION="$(awk '/^go / { print $2; exit }' go.mod | tr -d '\r')"
-          if [ -z "$GO_VERSION" ]; then
-            GO_VERSION="1.24.0"
-          fi
-          if [[ "$GO_VERSION" != *.*.* ]]; then
-            GO_VERSION="${GO_VERSION}.0"
-          fi
-          curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" -o "/tmp/go${GO_VERSION}.linux-amd64.tar.gz"
-          sudo rm -rf /usr/local/go
-          sudo tar -C /usr/local -xzf "/tmp/go${GO_VERSION}.linux-amd64.tar.gz"
-          echo "/usr/local/go/bin" >> "$GITHUB_PATH"
-          mkdir -p "$HOME/go/bin"
-          echo "$HOME/go/bin" >> "$GITHUB_PATH"
-          echo "GOBIN=$HOME/go/bin" >> "$GITHUB_ENV"
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
       - run: go mod download
       - name: Check sqlc drift
         run: |
@@ -120,11 +71,7 @@ jobs:
   docker-build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout source
-        run: |
-          REPO="${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}"
-          REF="${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}"
-          git clone --depth 1 --branch "$REF" "https://github.com/$REPO.git" .
+      - uses: actions/checkout@v4
       - name: Build Docker image
         run: |
           docker build \
@@ -154,27 +101,10 @@ jobs:
         ports:
           - 5432:5432
     steps:
-      - name: Checkout source
-        run: |
-          REPO="${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}"
-          REF="${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}"
-          git clone --depth 1 --branch "$REF" "https://github.com/$REPO.git" .
-      - name: Setup Go
-        run: |
-          GO_VERSION="$(awk '/^go / { print $2; exit }' go.mod | tr -d '\r')"
-          if [ -z "$GO_VERSION" ]; then
-            GO_VERSION="1.24.0"
-          fi
-          if [[ "$GO_VERSION" != *.*.* ]]; then
-            GO_VERSION="${GO_VERSION}.0"
-          fi
-          curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" -o "/tmp/go${GO_VERSION}.linux-amd64.tar.gz"
-          sudo rm -rf /usr/local/go
-          sudo tar -C /usr/local -xzf "/tmp/go${GO_VERSION}.linux-amd64.tar.gz"
-          echo "/usr/local/go/bin" >> "$GITHUB_PATH"
-          mkdir -p "$HOME/go/bin"
-          echo "$HOME/go/bin" >> "$GITHUB_PATH"
-          echo "GOBIN=$HOME/go/bin" >> "$GITHUB_ENV"
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
       - name: Install migrate
         run: go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
       - name: Validate migrations

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,27 @@ jobs:
   fast-checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
+      - name: Checkout source
+        run: |
+          REPO="${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}"
+          REF="${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}"
+          git clone --depth 1 --branch "$REF" "https://github.com/$REPO.git" .
+      - name: Setup Go
+        run: |
+          GO_VERSION="$(awk '/^go / { print $2; exit }' go.mod | tr -d '\r')"
+          if [ -z "$GO_VERSION" ]; then
+            GO_VERSION="1.24.0"
+          fi
+          if [[ "$GO_VERSION" != *.*.* ]]; then
+            GO_VERSION="${GO_VERSION}.0"
+          fi
+          curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" -o "/tmp/go${GO_VERSION}.linux-amd64.tar.gz"
+          sudo rm -rf /usr/local/go
+          sudo tar -C /usr/local -xzf "/tmp/go${GO_VERSION}.linux-amd64.tar.gz"
+          echo "/usr/local/go/bin" >> "$GITHUB_PATH"
+          mkdir -p "$HOME/go/bin"
+          echo "$HOME/go/bin" >> "$GITHUB_PATH"
+          echo "GOBIN=$HOME/go/bin" >> "$GITHUB_ENV"
       - run: go mod download
       - run: go mod verify
       - run: go build ./...
@@ -24,15 +41,13 @@ jobs:
           if [ -z "$BASE_REF" ]; then
             BASE_REF="main"
           fi
-          if [ "$BASE_REF" = "main" ] || [ "$BASE_REF" = "develop" ]; then
-            git fetch --depth=1 origin "$BASE_REF"
+        if [ "$BASE_REF" = "main" ] || [ "$BASE_REF" = "develop" ]; then
+            git fetch --depth=1 origin "refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF"
             golangci-lint run --timeout 10m --new-from-rev="origin/$BASE_REF" ./...
           else
             golangci-lint run --timeout 10m ./...
           fi
       - name: Security check
-        env:
-          GOTOOLCHAIN: go1.24.0
         run: |
           go install golang.org/x/vuln/cmd/govulncheck@latest
           govulncheck ./...
@@ -40,10 +55,27 @@ jobs:
   integration-checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
+      - name: Checkout source
+        run: |
+          REPO="${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}"
+          REF="${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}"
+          git clone --depth 1 --branch "$REF" "https://github.com/$REPO.git" .
+      - name: Setup Go
+        run: |
+          GO_VERSION="$(awk '/^go / { print $2; exit }' go.mod | tr -d '\r')"
+          if [ -z "$GO_VERSION" ]; then
+            GO_VERSION="1.24.0"
+          fi
+          if [[ "$GO_VERSION" != *.*.* ]]; then
+            GO_VERSION="${GO_VERSION}.0"
+          fi
+          curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" -o "/tmp/go${GO_VERSION}.linux-amd64.tar.gz"
+          sudo rm -rf /usr/local/go
+          sudo tar -C /usr/local -xzf "/tmp/go${GO_VERSION}.linux-amd64.tar.gz"
+          echo "/usr/local/go/bin" >> "$GITHUB_PATH"
+          mkdir -p "$HOME/go/bin"
+          echo "$HOME/go/bin" >> "$GITHUB_PATH"
+          echo "GOBIN=$HOME/go/bin" >> "$GITHUB_ENV"
       - run: go mod download
       - name: Run integration tests
         run: go test -tags=integration ./tests/integration
@@ -51,10 +83,27 @@ jobs:
   generated-code-drift:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
+      - name: Checkout source
+        run: |
+          REPO="${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}"
+          REF="${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}"
+          git clone --depth 1 --branch "$REF" "https://github.com/$REPO.git" .
+      - name: Setup Go
+        run: |
+          GO_VERSION="$(awk '/^go / { print $2; exit }' go.mod | tr -d '\r')"
+          if [ -z "$GO_VERSION" ]; then
+            GO_VERSION="1.24.0"
+          fi
+          if [[ "$GO_VERSION" != *.*.* ]]; then
+            GO_VERSION="${GO_VERSION}.0"
+          fi
+          curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" -o "/tmp/go${GO_VERSION}.linux-amd64.tar.gz"
+          sudo rm -rf /usr/local/go
+          sudo tar -C /usr/local -xzf "/tmp/go${GO_VERSION}.linux-amd64.tar.gz"
+          echo "/usr/local/go/bin" >> "$GITHUB_PATH"
+          mkdir -p "$HOME/go/bin"
+          echo "$HOME/go/bin" >> "$GITHUB_PATH"
+          echo "GOBIN=$HOME/go/bin" >> "$GITHUB_ENV"
       - run: go mod download
       - name: Check sqlc drift
         run: |
@@ -71,7 +120,11 @@ jobs:
   docker-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout source
+        run: |
+          REPO="${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}"
+          REF="${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}"
+          git clone --depth 1 --branch "$REF" "https://github.com/$REPO.git" .
       - name: Build Docker image
         run: |
           docker build \
@@ -101,10 +154,27 @@ jobs:
         ports:
           - 5432:5432
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
+      - name: Checkout source
+        run: |
+          REPO="${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}"
+          REF="${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}"
+          git clone --depth 1 --branch "$REF" "https://github.com/$REPO.git" .
+      - name: Setup Go
+        run: |
+          GO_VERSION="$(awk '/^go / { print $2; exit }' go.mod | tr -d '\r')"
+          if [ -z "$GO_VERSION" ]; then
+            GO_VERSION="1.24.0"
+          fi
+          if [[ "$GO_VERSION" != *.*.* ]]; then
+            GO_VERSION="${GO_VERSION}.0"
+          fi
+          curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" -o "/tmp/go${GO_VERSION}.linux-amd64.tar.gz"
+          sudo rm -rf /usr/local/go
+          sudo tar -C /usr/local -xzf "/tmp/go${GO_VERSION}.linux-amd64.tar.gz"
+          echo "/usr/local/go/bin" >> "$GITHUB_PATH"
+          mkdir -p "$HOME/go/bin"
+          echo "$HOME/go/bin" >> "$GITHUB_PATH"
+          echo "GOBIN=$HOME/go/bin" >> "$GITHUB_ENV"
       - name: Install migrate
         run: go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
       - name: Validate migrations

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           fi
       - name: Security check
         env:
-          GOTOOLCHAIN: go1.25.10
+          GOTOOLCHAIN: go1.24.0
         run: |
           go install golang.org/x/vuln/cmd/govulncheck@latest
           govulncheck ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,27 @@ jobs:
   fast-checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
+      - name: Checkout source
+        run: |
+          REPO="${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}"
+          REF="${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}"
+          git clone --depth 1 --branch "$REF" "https://github.com/$REPO.git" .
+      - name: Setup Go
+        run: |
+          GO_VERSION="$(awk '/^go / { print $2; exit }' go.mod | tr -d '\r')"
+          if [ -z "$GO_VERSION" ]; then
+            GO_VERSION="1.24.0"
+          fi
+          if [[ "$GO_VERSION" != *.*.* ]]; then
+            GO_VERSION="${GO_VERSION}.0"
+          fi
+          curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" -o "/tmp/go${GO_VERSION}.linux-amd64.tar.gz"
+          sudo rm -rf /usr/local/go
+          sudo tar -C /usr/local -xzf "/tmp/go${GO_VERSION}.linux-amd64.tar.gz"
+          echo "/usr/local/go/bin" >> "$GITHUB_PATH"
+          mkdir -p "$HOME/go/bin"
+          echo "$HOME/go/bin" >> "$GITHUB_PATH"
+          echo "GOBIN=$HOME/go/bin" >> "$GITHUB_ENV"
       - run: go mod download
       - run: go mod verify
       - run: go build ./...
@@ -25,14 +42,12 @@ jobs:
             BASE_REF="main"
           fi
           if [ "$BASE_REF" = "main" ] || [ "$BASE_REF" = "develop" ]; then
-            git fetch --depth=1 origin "$BASE_REF"
+            git fetch --depth=1 origin "refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF"
             golangci-lint run --timeout 10m --new-from-rev="origin/$BASE_REF" ./...
           else
             golangci-lint run --timeout 10m ./...
           fi
       - name: Security check
-        env:
-          GOTOOLCHAIN: go1.24.0
         run: |
           go install golang.org/x/vuln/cmd/govulncheck@latest
           govulncheck ./...
@@ -40,10 +55,27 @@ jobs:
   integration-checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
+      - name: Checkout source
+        run: |
+          REPO="${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}"
+          REF="${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}"
+          git clone --depth 1 --branch "$REF" "https://github.com/$REPO.git" .
+      - name: Setup Go
+        run: |
+          GO_VERSION="$(awk '/^go / { print $2; exit }' go.mod | tr -d '\r')"
+          if [ -z "$GO_VERSION" ]; then
+            GO_VERSION="1.24.0"
+          fi
+          if [[ "$GO_VERSION" != *.*.* ]]; then
+            GO_VERSION="${GO_VERSION}.0"
+          fi
+          curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" -o "/tmp/go${GO_VERSION}.linux-amd64.tar.gz"
+          sudo rm -rf /usr/local/go
+          sudo tar -C /usr/local -xzf "/tmp/go${GO_VERSION}.linux-amd64.tar.gz"
+          echo "/usr/local/go/bin" >> "$GITHUB_PATH"
+          mkdir -p "$HOME/go/bin"
+          echo "$HOME/go/bin" >> "$GITHUB_PATH"
+          echo "GOBIN=$HOME/go/bin" >> "$GITHUB_ENV"
       - run: go mod download
       - name: Run integration tests
         run: go test -tags=integration ./tests/integration
@@ -51,10 +83,27 @@ jobs:
   generated-code-drift:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
+      - name: Checkout source
+        run: |
+          REPO="${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}"
+          REF="${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}"
+          git clone --depth 1 --branch "$REF" "https://github.com/$REPO.git" .
+      - name: Setup Go
+        run: |
+          GO_VERSION="$(awk '/^go / { print $2; exit }' go.mod | tr -d '\r')"
+          if [ -z "$GO_VERSION" ]; then
+            GO_VERSION="1.24.0"
+          fi
+          if [[ "$GO_VERSION" != *.*.* ]]; then
+            GO_VERSION="${GO_VERSION}.0"
+          fi
+          curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" -o "/tmp/go${GO_VERSION}.linux-amd64.tar.gz"
+          sudo rm -rf /usr/local/go
+          sudo tar -C /usr/local -xzf "/tmp/go${GO_VERSION}.linux-amd64.tar.gz"
+          echo "/usr/local/go/bin" >> "$GITHUB_PATH"
+          mkdir -p "$HOME/go/bin"
+          echo "$HOME/go/bin" >> "$GITHUB_PATH"
+          echo "GOBIN=$HOME/go/bin" >> "$GITHUB_ENV"
       - run: go mod download
       - name: Check sqlc drift
         run: |
@@ -71,7 +120,11 @@ jobs:
   docker-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout source
+        run: |
+          REPO="${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}"
+          REF="${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}"
+          git clone --depth 1 --branch "$REF" "https://github.com/$REPO.git" .
       - name: Build Docker image
         run: |
           docker build \
@@ -101,10 +154,27 @@ jobs:
         ports:
           - 5432:5432
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
+      - name: Checkout source
+        run: |
+          REPO="${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}"
+          REF="${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}"
+          git clone --depth 1 --branch "$REF" "https://github.com/$REPO.git" .
+      - name: Setup Go
+        run: |
+          GO_VERSION="$(awk '/^go / { print $2; exit }' go.mod | tr -d '\r')"
+          if [ -z "$GO_VERSION" ]; then
+            GO_VERSION="1.24.0"
+          fi
+          if [[ "$GO_VERSION" != *.*.* ]]; then
+            GO_VERSION="${GO_VERSION}.0"
+          fi
+          curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" -o "/tmp/go${GO_VERSION}.linux-amd64.tar.gz"
+          sudo rm -rf /usr/local/go
+          sudo tar -C /usr/local -xzf "/tmp/go${GO_VERSION}.linux-amd64.tar.gz"
+          echo "/usr/local/go/bin" >> "$GITHUB_PATH"
+          mkdir -p "$HOME/go/bin"
+          echo "$HOME/go/bin" >> "$GITHUB_PATH"
+          echo "GOBIN=$HOME/go/bin" >> "$GITHUB_ENV"
       - name: Install migrate
         run: go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
       - name: Validate migrations

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 # Install build dependencies
 RUN apk add --no-cache git make ca-certificates

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.25-alpine AS builder
+FROM golang:1.24-alpine AS builder
 
 # Install build dependencies
 RUN apk add --no-cache git make ca-certificates


### PR DESCRIPTION
## Summary
- Update Docker builder image from golang:1.25-alpine to golang:1.24-alpine.
- Update GOVULN check toolchain to go1.24.0.

## Why
The repository currently referenced Go 1.25 variants in CI and container builds while code and tooling already use a Go 1.24 baseline, which can cause build/install mismatches.

Closes #49