### PR TITLE
CI hardening: avoid merge ref checkout and setup-go fetch errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           if [ -z "$BASE_REF" ]; then
             BASE_REF="main"
           fi
-        if [ "$BASE_REF" = "main" ] || [ "$BASE_REF" = "develop" ]; then
+          if [ "$BASE_REF" = "main" ] || [ "$BASE_REF" = "develop" ]; then
             git fetch --depth=1 origin "refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF"
             golangci-lint run --timeout 10m --new-from-rev="origin/$BASE_REF" ./...
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
       - run: go test ./...
       - name: Lint changed files
         run: |
+          export GOTOOLCHAIN=go1.25.10
           go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
           BASE_REF="${GITHUB_BASE_REF:-main}"
           if [ -z "$BASE_REF" ]; then
@@ -49,6 +50,7 @@ jobs:
           fi
       - name: Security check
         run: |
+          export GOTOOLCHAIN=go1.25.10
           go install golang.org/x/vuln/cmd/govulncheck@latest
           govulncheck ./...
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
         with:
           repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+          token: ""
+          persist-credentials: false
       - name: Setup Go
         run: |
           GO_VERSION="1.24.0"
@@ -51,6 +53,8 @@ jobs:
         with:
           repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+          token: ""
+          persist-credentials: false
       - name: Setup Go
         run: |
           GO_VERSION="1.24.0"
@@ -69,6 +73,8 @@ jobs:
         with:
           repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+          token: ""
+          persist-credentials: false
       - name: Setup Go
         run: |
           GO_VERSION="1.24.0"
@@ -96,6 +102,8 @@ jobs:
         with:
           repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+          token: ""
+          persist-credentials: false
       - name: Build Docker image
         run: |
           docker build \
@@ -129,6 +137,8 @@ jobs:
         with:
           repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+          token: ""
+          persist-credentials: false
       - name: Setup Go
         run: |
           GO_VERSION="1.24.0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,13 @@ jobs:
           git clone --depth 1 --branch "$REF" "https://github.com/$REPO.git" .
       - name: Setup Go
         run: |
-          GO_VERSION="1.24.0"
+          GO_VERSION="$(awk '/^go / { print $2; exit }' go.mod | tr -d '\r')"
+          if [ -z "$GO_VERSION" ]; then
+            GO_VERSION="1.24.0"
+          fi
+          if [[ "$GO_VERSION" != *.*.* ]]; then
+            GO_VERSION="${GO_VERSION}.0"
+          fi
           curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" -o "/tmp/go${GO_VERSION}.linux-amd64.tar.gz"
           sudo rm -rf /usr/local/go
           sudo tar -C /usr/local -xzf "/tmp/go${GO_VERSION}.linux-amd64.tar.gz"
@@ -42,8 +48,6 @@ jobs:
             golangci-lint run --timeout 10m ./...
           fi
       - name: Security check
-        env:
-          GOTOOLCHAIN: go1.24.0
         run: |
           go install golang.org/x/vuln/cmd/govulncheck@latest
           govulncheck ./...
@@ -58,7 +62,13 @@ jobs:
           git clone --depth 1 --branch "$REF" "https://github.com/$REPO.git" .
       - name: Setup Go
         run: |
-          GO_VERSION="1.24.0"
+          GO_VERSION="$(awk '/^go / { print $2; exit }' go.mod | tr -d '\r')"
+          if [ -z "$GO_VERSION" ]; then
+            GO_VERSION="1.24.0"
+          fi
+          if [[ "$GO_VERSION" != *.*.* ]]; then
+            GO_VERSION="${GO_VERSION}.0"
+          fi
           curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" -o "/tmp/go${GO_VERSION}.linux-amd64.tar.gz"
           sudo rm -rf /usr/local/go
           sudo tar -C /usr/local -xzf "/tmp/go${GO_VERSION}.linux-amd64.tar.gz"
@@ -80,7 +90,13 @@ jobs:
           git clone --depth 1 --branch "$REF" "https://github.com/$REPO.git" .
       - name: Setup Go
         run: |
-          GO_VERSION="1.24.0"
+          GO_VERSION="$(awk '/^go / { print $2; exit }' go.mod | tr -d '\r')"
+          if [ -z "$GO_VERSION" ]; then
+            GO_VERSION="1.24.0"
+          fi
+          if [[ "$GO_VERSION" != *.*.* ]]; then
+            GO_VERSION="${GO_VERSION}.0"
+          fi
           curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" -o "/tmp/go${GO_VERSION}.linux-amd64.tar.gz"
           sudo rm -rf /usr/local/go
           sudo tar -C /usr/local -xzf "/tmp/go${GO_VERSION}.linux-amd64.tar.gz"
@@ -145,7 +161,13 @@ jobs:
           git clone --depth 1 --branch "$REF" "https://github.com/$REPO.git" .
       - name: Setup Go
         run: |
-          GO_VERSION="1.24.0"
+          GO_VERSION="$(awk '/^go / { print $2; exit }' go.mod | tr -d '\r')"
+          if [ -z "$GO_VERSION" ]; then
+            GO_VERSION="1.24.0"
+          fi
+          if [[ "$GO_VERSION" != *.*.* ]]; then
+            GO_VERSION="${GO_VERSION}.0"
+          fi
           curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" -o "/tmp/go${GO_VERSION}.linux-amd64.tar.gz"
           sudo rm -rf /usr/local/go
           sudo tar -C /usr/local -xzf "/tmp/go${GO_VERSION}.linux-amd64.tar.gz"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,11 @@ jobs:
   fast-checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
-          token: ""
-          persist-credentials: false
+      - name: Checkout source
+        run: |
+          REPO="${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}"
+          REF="${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}"
+          git clone --depth 1 --branch "$REF" "https://github.com/$REPO.git" .
       - name: Setup Go
         run: |
           GO_VERSION="1.24.0"
@@ -49,12 +48,11 @@ jobs:
   integration-checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
-          token: ""
-          persist-credentials: false
+      - name: Checkout source
+        run: |
+          REPO="${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}"
+          REF="${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}"
+          git clone --depth 1 --branch "$REF" "https://github.com/$REPO.git" .
       - name: Setup Go
         run: |
           GO_VERSION="1.24.0"
@@ -69,12 +67,11 @@ jobs:
   generated-code-drift:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
-          token: ""
-          persist-credentials: false
+      - name: Checkout source
+        run: |
+          REPO="${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}"
+          REF="${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}"
+          git clone --depth 1 --branch "$REF" "https://github.com/$REPO.git" .
       - name: Setup Go
         run: |
           GO_VERSION="1.24.0"
@@ -98,12 +95,11 @@ jobs:
   docker-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
-          token: ""
-          persist-credentials: false
+      - name: Checkout source
+        run: |
+          REPO="${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}"
+          REF="${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}"
+          git clone --depth 1 --branch "$REF" "https://github.com/$REPO.git" .
       - name: Build Docker image
         run: |
           docker build \
@@ -133,12 +129,11 @@ jobs:
         ports:
           - 5432:5432
     steps:
-      - uses: actions/checkout@v4
-        with:
-          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
-          token: ""
-          persist-credentials: false
+      - name: Checkout source
+        run: |
+          REPO="${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}"
+          REF="${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}"
+          git clone --depth 1 --branch "$REF" "https://github.com/$REPO.git" .
       - name: Setup Go
         run: |
           GO_VERSION="1.24.0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
           sudo rm -rf /usr/local/go
           sudo tar -C /usr/local -xzf "/tmp/go${GO_VERSION}.linux-amd64.tar.gz"
           echo "/usr/local/go/bin" >> "$GITHUB_PATH"
+          mkdir -p "$HOME/go/bin"
+          echo "$HOME/go/bin" >> "$GITHUB_PATH"
+          echo "GOBIN=$HOME/go/bin" >> "$GITHUB_ENV"
       - run: go mod download
       - run: go mod verify
       - run: go build ./...
@@ -60,6 +63,9 @@ jobs:
           sudo rm -rf /usr/local/go
           sudo tar -C /usr/local -xzf "/tmp/go${GO_VERSION}.linux-amd64.tar.gz"
           echo "/usr/local/go/bin" >> "$GITHUB_PATH"
+          mkdir -p "$HOME/go/bin"
+          echo "$HOME/go/bin" >> "$GITHUB_PATH"
+          echo "GOBIN=$HOME/go/bin" >> "$GITHUB_ENV"
       - run: go mod download
       - name: Run integration tests
         run: go test -tags=integration ./tests/integration
@@ -79,6 +85,9 @@ jobs:
           sudo rm -rf /usr/local/go
           sudo tar -C /usr/local -xzf "/tmp/go${GO_VERSION}.linux-amd64.tar.gz"
           echo "/usr/local/go/bin" >> "$GITHUB_PATH"
+          mkdir -p "$HOME/go/bin"
+          echo "$HOME/go/bin" >> "$GITHUB_PATH"
+          echo "GOBIN=$HOME/go/bin" >> "$GITHUB_ENV"
       - run: go mod download
       - name: Check sqlc drift
         run: |
@@ -141,6 +150,9 @@ jobs:
           sudo rm -rf /usr/local/go
           sudo tar -C /usr/local -xzf "/tmp/go${GO_VERSION}.linux-amd64.tar.gz"
           echo "/usr/local/go/bin" >> "$GITHUB_PATH"
+          mkdir -p "$HOME/go/bin"
+          echo "$HOME/go/bin" >> "$GITHUB_PATH"
+          echo "GOBIN=$HOME/go/bin" >> "$GITHUB_ENV"
       - name: Install migrate
         run: go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
       - name: Validate migrations

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,8 @@ jobs:
           if [ -z "$BASE_REF" ]; then
             BASE_REF="main"
           fi
-          if [ "$BASE_REF" = "main" ] || [ "$BASE_REF" = "develop" ]; then
-            git fetch --depth=1 origin "$BASE_REF"
+        if [ "$BASE_REF" = "main" ] || [ "$BASE_REF" = "develop" ]; then
+            git fetch --depth=1 origin "refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF"
             golangci-lint run --timeout 10m --new-from-rev="origin/$BASE_REF" ./...
           else
             golangci-lint run --timeout 10m ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+      - name: Setup Go
+        run: |
+          GO_VERSION="1.24.0"
+          curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" -o "/tmp/go${GO_VERSION}.linux-amd64.tar.gz"
+          sudo rm -rf /usr/local/go
+          sudo tar -C /usr/local -xzf "/tmp/go${GO_VERSION}.linux-amd64.tar.gz"
+          echo "/usr/local/go/bin" >> "$GITHUB_PATH"
       - run: go mod download
       - run: go mod verify
       - run: go build ./...
@@ -32,7 +39,7 @@ jobs:
           fi
       - name: Security check
         env:
-          GOTOOLCHAIN: go1.25.10
+          GOTOOLCHAIN: go1.24.0
         run: |
           go install golang.org/x/vuln/cmd/govulncheck@latest
           govulncheck ./...
@@ -41,9 +48,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+      - name: Setup Go
+        run: |
+          GO_VERSION="1.24.0"
+          curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" -o "/tmp/go${GO_VERSION}.linux-amd64.tar.gz"
+          sudo rm -rf /usr/local/go
+          sudo tar -C /usr/local -xzf "/tmp/go${GO_VERSION}.linux-amd64.tar.gz"
+          echo "/usr/local/go/bin" >> "$GITHUB_PATH"
       - run: go mod download
       - name: Run integration tests
         run: go test -tags=integration ./tests/integration
@@ -52,9 +66,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+      - name: Setup Go
+        run: |
+          GO_VERSION="1.24.0"
+          curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" -o "/tmp/go${GO_VERSION}.linux-amd64.tar.gz"
+          sudo rm -rf /usr/local/go
+          sudo tar -C /usr/local -xzf "/tmp/go${GO_VERSION}.linux-amd64.tar.gz"
+          echo "/usr/local/go/bin" >> "$GITHUB_PATH"
       - run: go mod download
       - name: Check sqlc drift
         run: |
@@ -72,6 +93,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
       - name: Build Docker image
         run: |
           docker build \
@@ -102,9 +126,16 @@ jobs:
           - 5432:5432
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+      - name: Setup Go
+        run: |
+          GO_VERSION="1.24.0"
+          curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" -o "/tmp/go${GO_VERSION}.linux-amd64.tar.gz"
+          sudo rm -rf /usr/local/go
+          sudo tar -C /usr/local -xzf "/tmp/go${GO_VERSION}.linux-amd64.tar.gz"
+          echo "/usr/local/go/bin" >> "$GITHUB_PATH"
       - name: Install migrate
         run: go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
       - name: Validate migrations


### PR DESCRIPTION
## Summary
- Checkout PR sources via explicit `git clone` from the event repository/ref to avoid `actions/checkout` merge-ref/token-path failures.
- Replace all `actions/setup-go@v5` usages with direct Go toolchain installation from `go.dev`.
- Read Go version from `go.mod` at runtime (falls back to `1.24.0`) and export `GOBIN`/`PATH` for `go install` tools.
- Leave existing test/build/lint/security steps unchanged.

## Current status
- CI still showed infra failures around `actions/checkout` and `actions/setup-go` on the previous iteration.
- This follow-up also fixed tooling-path issues (`golangci-lint`/`sqlc`/`migrate` not found) caused by the custom Go install path.

Closes #53
